### PR TITLE
One bugfix and two security fixes

### DIFF
--- a/softsusy.cpp
+++ b/softsusy.cpp
@@ -2419,6 +2419,7 @@ double MssmSoftsusy::calcRunningMb() const {
   double    mH      = forLoops.mH0;
   double    mHp     = forLoops.mHpm;
   double    mz = displayMzRun();
+  double    mw = displayMwRun();
   double    thetaWDRbar = asin(calcSinthdrbar());
   double    cw2DRbar    = sqr(cos(thetaWDRbar));
   double    ca      = cos(forLoops.thetaH);
@@ -2595,6 +2596,7 @@ double MssmSoftsusy::calcRunningMtau() const {
   double    mH      = forLoops.mH0;
   double    mHp     = forLoops.mHpm;
   double    mz = displayMzRun();
+  double    mw = displayMwRun();
   double    thetaWDRbar = asin(calcSinthdrbar());
   double    cw2DRbar    = sqr(cos(thetaWDRbar));
   double    ca      = cos(forLoops.thetaH);


### PR DESCRIPTION
Hi Ben,

Peter and me found two problems in softsusy.cpp:
1. addSbotCorrection() was called with the running bottom mass as last parameter.  We think the running top mass would be correct.
2. When comparing our generated MSSM and NMSSM classes with Softsusy we call calcRunningMtau() and calcRunningMb() in a different way than Softsusy does.  In our cases mw was not correctly set to the running W mass (instead is was set to zero).  For security reasons we think it would be best to explicitely set mw to the running W mass.

Best,
Alex
