### PR TITLE
avoid fall through if entry 13 is set in block SOFTSUSY

### DIFF
--- a/softpoint.cpp
+++ b/softpoint.cpp
@@ -848,6 +848,7 @@ int main(int argc, char *argv[]) {
 		    int num = int(d + EPSTOL);
 		    if (num == 1) mAFlag = true;		  
 		  }
+                    break;
 		  case 14: {
 		    int num = int(d + EPSTOL);
 		    if (num == 1) tryToConvergeHard = true;		  


### PR DESCRIPTION
Dear Ben,

I noticed a fall through in a switch statement in softpoint.cpp at line 851:  If entry 13 (mAFlag) is set in block SOFTSUSY, entry 14 (tryToConvergeHard) will be set to the same value.

I think this behaviour is not intended and this patch fixes the issue.

Best,
Alex
