### PR TITLE
distributing src/nmProcessSpec.f

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -42,3 +42,5 @@ susy.cpp utils.cpp mssmUtils.cpp \
 tensor.cpp rpvsusypars.cpp rpvsoft.cpp flavoursoft.cpp twoloophiggs.f 
 
 libsoft_la_LDFLAGS = @FLIBS@
+
+EXTRA_DIST = nmProcessSpec.f


### PR DESCRIPTION
Need to distribute `src/nmProcessSpec.f` to make `setup_nmssmtools.sh` work.
