### PR TITLE
Nmssm manual fixes

### DIFF
--- a/doc/nmssmManual.tex
+++ b/doc/nmssmManual.tex
@@ -153,7 +153,7 @@ NMSSM, Higgs
 {\em Programming language:} {\tt C++}, {\tt fortran}\\
 {\em Computer:}\/ Personal computer.\\
 {\em Operating system:}\/ Tested on Linux 3.x\\
-{\em Word size:}\/ 32 bits.\\
+{\em Word size:}\/ 64 bits.\\
 {\em External routines:}\/ None.\\
 {\em Typical running time:}\/ A few seconds per parameter point.\\
 {\em Nature of problem:}\/ Calculating supersymmetric particle spectrum and


### PR DESCRIPTION
These commits fix some spacing problems and typos in the NMSSM manual.
