### PR TITLE
correcting TeX comments in the SLHA output blocks

### DIFF
--- a/src/flavoursoft.cpp
+++ b/src/flavoursoft.cpp
@@ -594,7 +594,7 @@ void FlavourMssmSoftsusy::msoftSLHA(ostream & out) {
       for (j=1; j<=3; j++) {
 	out << "  " << i << "  " << j << "    "; 
 	printRow(out, mqSqSckm(i, j));
-	out << "    # (m^_Q^2)_{" << i << j << "}" << endl;
+	out << "    # (m_Q^2)_{" << i << j << "}" << endl;
       }
     
     out << "Block msl2 Q= " << displayMu() << " # super MNS slepton mass^2 matrix"
@@ -603,7 +603,7 @@ void FlavourMssmSoftsusy::msoftSLHA(ostream & out) {
       for (j=1; j<=3; j++) {
 	out << "  " << i << "  " << j << "    "; 
 	printRow(out, mlSqSckm(i, j));
-	out << "    # (m^_L^2)_{" << i << j << "}" << endl;
+	out << "    # (m_L^2)_{" << i << j << "}" << endl;
       }
     
     out << "Block msd2 Q= " << displayMu() << " # super CKM squark mass^2 matrix"
@@ -612,7 +612,7 @@ void FlavourMssmSoftsusy::msoftSLHA(ostream & out) {
       for (j=1; j<=3; j++) {
 	out << "  " << i << "  " << j << "    "; 
 	printRow(out, mdSqSckm(i, j));
-	out << "    # (m^_d^2)_{" << i << j << "}" << endl;
+	out << "    # (m_d^2)_{" << i << j << "}" << endl;
       }
     
     out << "Block msu2 Q= " << displayMu() << " # super CKM squark mass^2 matrix"
@@ -621,7 +621,7 @@ void FlavourMssmSoftsusy::msoftSLHA(ostream & out) {
       for (j=1; j<=3; j++) {
 	out << "  " << i << "  " << j << "    "; 
 	printRow(out, muSqSckm(i, j));
-	out << "    # (m^_u^2)_{" << i << j << "}" << endl;
+	out << "    # (m_u^2)_{" << i << j << "}" << endl;
       }
     
     out << "Block mse2 Q= " << displayMu() << " # super MNS slepton mass^2 matrix"
@@ -630,7 +630,7 @@ void FlavourMssmSoftsusy::msoftSLHA(ostream & out) {
       for (j=1; j<=3; j++) {
 	out << "  " << i << "  " << j << "    "; 
 	printRow(out, meSqSckm(i, j));
-	out << "    # (m^_e^2)_{" << i << j << "}" << endl;
+	out << "    # (m_e^2)_{" << i << j << "}" << endl;
       }
     
     out << "Block tu Q= " << displayMu() << "   # super CKM trilinear matrix"
@@ -639,7 +639,7 @@ void FlavourMssmSoftsusy::msoftSLHA(ostream & out) {
       for (j=1; j<=3; j++) {
 	out << "  " << i << "  " << j << "    "; 
 	printRow(out, tuSckm(i, j));
-	out << "    # (T^_u)_{" << i << j << "}" << endl;
+	out << "    # (T_u)_{" << i << j << "}" << endl;
       }
     
     out << "Block td Q= " << displayMu() << "   # super CKM trilinear matrix"
@@ -648,7 +648,7 @@ void FlavourMssmSoftsusy::msoftSLHA(ostream & out) {
       for (j=1; j<=3; j++) {
 	out << "  " << i << "  " << j << "    "; 
 	printRow(out, tdSckm(i, j));
-	out << "    # (T^_d)_{" << i << j << "}" << endl;
+	out << "    # (T_d)_{" << i << j << "}" << endl;
       }
     
     out << "Block te Q= " << displayMu() << "   # super CKM trilinear matrix"
@@ -657,7 +657,7 @@ void FlavourMssmSoftsusy::msoftSLHA(ostream & out) {
       for (j=1; j<=3; j++) {
 	out << "  " << i << "  " << j << "    "; 
 	printRow(out, teSckm(i, j));
-	out << "    # (T^_e)_{" << i << j << "}" << endl;
+	out << "    # (T_e)_{" << i << j << "}" << endl;
       }
   DoubleMatrix vCkm(Vu.transpose() * Vd);
 


### PR DESCRIPTION
Dear Ben,

I think there are some small typos in the comments of various SLHA output blocks.  For example the file `.test/slha2Output` contains the block

 Block msl2 Q= 8.83269909e+02 # super MNS slepton mass^2 matrix - DRbar
   1  1     1.25271482e+05    # (m^_L^2)_{11}
   1  2     0.00000000e+00    # (m^_L^2)_{12}
   1  3     0.00000000e+00    # (m^_L^2)_{13}
   2  1     0.00000000e+00    # (m^_L^2)_{21}

Here the TeX comments are malformed, because they contain `^_`.
This pull request fixes these bugs.

Best,
Alex
