### PR TITLE
fix possible buffer overflows

### DIFF
--- a/src/flavoursoft.cpp
+++ b/src/flavoursoft.cpp
@@ -1187,7 +1187,7 @@ ostream & operator <<(ostream & left, const flavourPhysical &s) {
 }
 
 istream & operator >>(istream & left, flavourPhysical &s) {
-  char c[70];
+  string c;
   left >> c >> s.msU;
   left >> c >> c >> s.uSqMix;
   

--- a/src/lowe.cpp
+++ b/src/lowe.cpp
@@ -101,7 +101,7 @@ ostream & operator <<(ostream &left, const QedQcd &m) {
 
 istream & operator >>(istream &left, QedQcd &m) {
 
-  char c[12], cmbmb[12], cmbpole[12];
+  string c, cmbmb, cmbpole;
   double mu, mc, mtpole, md, ms, me, mmu, mtau, invalph, 
     alphas, scale;
   int t, l;
@@ -129,7 +129,7 @@ istream & operator >>(istream &left, QedQcd &m) {
 
   m.setMass(mTop, getRunMtFromMz(mtpole, alphas));
 
-  if (!strcmp(cmbmb, "?") && !strcmp(cmbpole, "?")) {
+  if (cmbmb == "?" && cmbpole == "?") {
     ostringstream ii;
     ii << "Error reading in low energy QCDQED object: must specify ";
     ii << "running AND/OR pole bottom mass" << endl;
@@ -138,11 +138,11 @@ istream & operator >>(istream &left, QedQcd &m) {
 
   // If you set one of the bottom mass parameters to be "?", it will calculate
   // it from the other one
-  if (strcmp(cmbmb, "?") != 0) m.setMass(mBottom, atof(cmbmb)); 
-  if (strcmp(cmbpole, "?") != 0) m.setPoleMb(atof(cmbpole)); 
+  if (cmbmb != "?") m.setMass(mBottom, atof(cmbmb.c_str()));
+  if (cmbpole != "?") m.setPoleMb(atof(cmbpole.c_str()));
 
-  if (strcmp(cmbmb, "?") == 0) m.calcRunningMb();
-  if (strcmp(cmbpole, "?") == 0) m.calcPoleMb();
+  if (cmbmb == "?") m.calcRunningMb();
+  if (cmbpole == "?") m.calcPoleMb();
 
   return left;
 }
@@ -446,7 +446,7 @@ void readIn(QedQcd &mset, const char fname[80]) {
 
   // Read in data if it's not been set
   if (accessedReadIn == 0) {
-    char c[14];
+    string c;
     if (!strcmp(fname,"")) cin >> prevReadIn >> c >> MIXING >> c >> TOLERANCE 
 			       >> c >> PRINTOUT; // from standard input 
     else {   

--- a/src/nmssmsoftpars.cpp
+++ b/src/nmssmsoftpars.cpp
@@ -780,14 +780,14 @@ ostream & operator <<(ostream &left, const SoftParsNmssm &s) {
 
 void SoftParsNmssm::inputSoftParsOnly() {
   SoftPars<NmssmSusy, nmsBrevity>::inputSoftParsOnly();
-  char c[70];
+  string c;
   cin >> c >> mSsq >> c >> mSpsq >> c >> xiS;
   cin >> c >> alambda
       >> c >> akappa;
 }
 
 istream & operator >>(istream &left, SoftParsNmssm &s) {
-  char c[70];
+  string c;
 
   left >> c >> c >> c >> c >> c >> c >> c;
   DoubleMatrix ua(3, 3), da(3, 3), ea(3, 3);

--- a/src/physpars.cpp
+++ b/src/physpars.cpp
@@ -95,7 +95,7 @@ std::ostream & operator <<(std::ostream & left, const sPhysical &s) {
 }
 
 std::istream & operator >>(std::istream & left, sPhysical &s) {
-  char c[70];
+  string c;
   left >> c >> c >> c >> c;
   left >> c >> s.mh0 >> c >> s.mA0
        >> c >> s.mHpm;

--- a/src/softpars.cpp
+++ b/src/softpars.cpp
@@ -1269,7 +1269,7 @@ ostream & operator <<(ostream &left, const SoftPars<Susy, Brevity> &s) {
 
 template<class Susy, class Brevity>
 void SoftPars<Susy, Brevity>::inputSoftParsOnly() {
-  char c[70];
+  string c;
 
   cin >> c >> c >> c >> c >> c;
   cin >> c >> ua
@@ -1286,7 +1286,7 @@ void SoftPars<Susy, Brevity>::inputSoftParsOnly() {
 
 template<class Susy, class Brevity>
 istream & operator >>(istream &left, SoftPars<Susy, Brevity> &s) {
-  char c[70];
+  string c;
 
   left >> c >> c >> c >> c >> c >> c >> c;
   DoubleMatrix ua(3, 3), da(3, 3), ea(3, 3);

--- a/src/susy.cpp
+++ b/src/susy.cpp
@@ -207,7 +207,7 @@ void MssmSusy::setSusy(const MssmSusy & s) {
 }
 
 istream & operator >>(istream &left, MssmSusy &s) {
-  char c[70];
+  string c;
   DoubleMatrix u(3, 3), d(3, 3), e(3, 3);
   double g1, g2, g3, smu, mu, tanb, hv;
   int loops, thresh;


### PR DESCRIPTION
Hi Ben,

I found that Softsusy can crash due to some buffer overflows.  This pull request fixes these buffer overflows by replacing the fixed-size char arrarys by C++ strings.  I'm not sure if these fixes should go into the updated version of Softsusy that we prepare for CPC.  I guess a later Softsusy update with these fixes would be fine.

Best,
Alex
