### PR TITLE
Removing unused NMSSM two-loop Higgs function calls

### DIFF
--- a/src/nmssmsoftsusy.cpp
+++ b/src/nmssmsoftsusy.cpp
@@ -4082,28 +4082,19 @@ bool NmssmSoftsusy::higgs(int accuracy, double piwwtMS, double /* pizztMS */,
 	 
 	 //PA: Make appropriate substitutions for elements following 0907.4682
 	 // bottom of page 9
-	 
-	 double temp = DMSB[0][0];
-	 DMSB[0][0] = DMSB[1][1];
-	 DMSB[1][1] = temp;
-	 temp = DMSB[0][2];
-	 DMSB[0][2] = DMSB[1][2];
-	 DMSB[1][2] = temp;
+         std::swap(DMSB[0][0], DMSB[1][1]);
+         std::swap(DMSB[0][2], DMSB[1][2]);
 
 	 /// LCT: Obtain the O(alpha_b alpha_s) corrections from O(alpha_t alpha_s) 
 	 /// parts by interchanging the (1, 1) <--> (2, 2) and (1, 3) <--> (2, 3) 
 	 /// matrix elements of CP-odd mass matrix (as in 0907.4682)
-	 double temp2 = DMPB[0][0];
-	 DMPB[0][0] = DMPB[1][1];
-	 DMPB[1][1] = temp2;
-	 temp2 = DMPB[0][2];
-	 DMPB[0][2] = DMPB[1][2];
-	 DMPB[1][2] = temp2;
+         std::swap(DMPB[0][0], DMPB[1][1]);
+         std::swap(DMPB[0][2], DMPB[1][2]);
 
 	 for(int i=0; i<=2; i++){
 	   for(int j=0; j<=2; j++){
-	     DMS[i][j] = DMS[i][j] + DMSB[i][j];
-	     DMP[i][j] = DMP[i][j] + DMPB[i][j]; 
+	     DMS[i][j] += DMSB[i][j];
+	     DMP[i][j] += DMPB[i][j];
 	   }
 	 }
 	 double amu = - lam * svev / root2;


### PR DESCRIPTION
Dear Ben,

Peter found that the output of some NMSSM two-loop Higgs function calls in `nmssmsoftsusy.cpp` are unused (they were used for testing in the past).  These commits remove these function calls and do a little clean-up.

If you agree with these changes, please feel free to merge them into your master branch.

Best,
Alex
