### PR TITLE
adding missing implementation of operator=(const NmssmSoftsusy&)

### DIFF
--- a/src/nmssmsoftsusy.cpp
+++ b/src/nmssmsoftsusy.cpp
@@ -14,6 +14,16 @@ namespace softsusy {
 extern double sw2, gnuL, guL, gdL, geL, guR, gdR, geR, yuL, yuR, ydL,
   ydR, yeL, yeR, ynuL;
 
+
+const NmssmSoftsusy & NmssmSoftsusy::operator=(const NmssmSoftsusy & s) {
+  if (this == &s) return *this;
+  Softsusy<SoftParsNmssm>::operator=(s);
+  tSOVSMs = s.tSOVSMs;
+  tSOVSMs1loop = s.tSOVSMs1loop;
+  return *this;
+}
+
+
  //PA: A print method used in development.  I find it useful and easier to read than couting the normal display function or calling printlong etc.
 void NmssmSoftsusy::printall() const {
    cout << "At scale " << displayMu() << '\n';


### PR DESCRIPTION
Hi Ben,

I found that `operator=(const NmssmSoftsusy&)` is not implemented.  This will lead to linking problems when a user tries to copy one `NmssmSoftsusy` object to another one using this operator.

This pull request will add the implementation of `operator=(const NmssmSoftsusy&)`.

Best regards,
Alex
