### PR TITLE
double-counting of eps-scalars in mb routine fixed

### DIFF
--- a/src/softsusy.amk
+++ b/src/softsusy.amk
@@ -64,6 +64,9 @@ softsusy_nmssm_x_LDADD += lib2lthresh.la libmssmparam.la
 softpoint_x_SOURCES += src/two_loop_thresholds/twoloopbubble.cpp 
 softpoint_x_LDADD += lib2lthresh.la libmssmparam.la 
 
+testDecay_x_SOURCES += src/two_loop_thresholds/twoloopbubble.cpp 
+testDecay_x_LDADD += lib2lthresh.la libmssmparam.la 
+
 rpvsoftsusy_x_LDADD += lib2lthresh.la libmssmparam.la 
 rpvneut_x_LDADD     += lib2lthresh.la libmssmparam.la 
 endif COMPILE_TWO_LOOP_GAUGE_YUKAWA

--- a/src/softsusy.cpp
+++ b/src/softsusy.cpp
@@ -2894,6 +2894,12 @@ double MssmSoftsusy::calcRunningMb() {
 	if (is_a<numeric>(test))
 	  dzetamb += ex_to<numeric>(test).to_double();
       }
+
+     // AVB: fix double-counting of eps-scalar contribution
+     double alphasMZ = sqr(displayGaugeCoupling(3)) / (4.0 * PI);
+     dzetamb-= + 31.0 / 72.0 * sqr(alphasMZ) / sqr(PI) // pure QCD 
+	        + alphasMZ/(3.0 * PI) * decoupling_corrections.dmb.one_loop; // due to factrorization of one-loop term
+
       if (close(dzetamb, decoupling_corrections.dmb.two_loop, 
 		TWOLOOP_NUM_THRESH)) needcalc = false; 
       decoupling_corrections.dmb.two_loop = dzetamb;


### PR DESCRIPTION
Fix to avoid double-counting of gluon epsilon-scalar contribution in two-loop decoupling correction to the running bottom-quark mass. The subtracted terms account for the fact that the SM MSbar mass was converted to SM DRbar mass in the beginning of calcRunningMb()