### PR TITLE
speed-up configure/make cycle

### DIFF
--- a/src/def.h
+++ b/src/def.h
@@ -12,10 +12,6 @@
 #ifndef DEF_H
 #define DEF_H
 
-#ifdef HAVE_CONFIG_H
- #include <config.h>
-#endif
-
 #include <cmath>
 namespace softsusy{
   /// uncomment if you want checking of vector/matrices bounds: slows code

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,11 @@
 #include "main.h"
 #include "nmssmsoftsusy.h"
 #include "decays.h"
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 using namespace softsusy;
 
 int main() {

--- a/src/mssmUtils.cpp
+++ b/src/mssmUtils.cpp
@@ -2,6 +2,10 @@
 #include "mssmUtils.h"
 #include <iostream>
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 namespace softsusy {
   
   void generalBcs(MssmSoftsusy & m, const DoubleVector & inputParameters) {

--- a/src/nmssmsoftsusy.cpp
+++ b/src/nmssmsoftsusy.cpp
@@ -9,6 +9,14 @@
 
 #ifdef NMSSMSOFTSUSY_H
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef COMPILE_TWO_LOOP_SPARTICLE_MASS
+#include "higher_order.h"
+#endif
+
 namespace softsusy {
   
   extern double sw2, gnuL, guL, gdL, geL, guR, gdR, geR, yuL, yuR, ydL,

--- a/src/nmssmsoftsusy.h
+++ b/src/nmssmsoftsusy.h
@@ -30,11 +30,6 @@
 #include "nmssmUtils.h"
 #include <cassert>
 
-#ifdef COMPILE_TWO_LOOP_SPARTICLE_MASS
-//#include "supermodel/supermodel-v0.1/supermodel.h"
-#include "higher_order.h"
-#endif
-
 namespace softsusy {
   
   /* class NmssmSoftsusy;  */

--- a/src/numerics.cpp
+++ b/src/numerics.cpp
@@ -9,6 +9,14 @@
 
 #include "numerics.h"
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef USE_LOOPTOOLS
+#include "clooptools.h"
+#endif
+
 double dgauss(double (*f)(double x), double a, double b, double eps) {
   static DoubleVector w(12), x(12);
   /// set the initial values if they are uninitialised

--- a/src/numerics.h
+++ b/src/numerics.h
@@ -21,9 +21,6 @@
 #include <iostream>
 #include "linalg.h"
 #include "dilogwrap.h"
-#ifdef USE_LOOPTOOLS
-#include "clooptools.h"
-#endif
 using namespace softsusy;
 
 /// adaptive Gaussian one dimensional integration of f(x) between a and b to

--- a/src/rpvmain.cpp
+++ b/src/rpvmain.cpp
@@ -13,6 +13,10 @@
 
 #include "rpvmain.h"
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 int main() {
   /// Sets up exception handling
   signal(SIGFPE, FPE_ExceptionHandler); 

--- a/src/rpvneut.cpp
+++ b/src/rpvneut.cpp
@@ -7,6 +7,10 @@
 
 #include "rpvneut.h"
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 namespace softsusy {
 
 const RpvNeutrino & RpvNeutrino::operator = (const RpvNeutrino &s) {

--- a/src/softpars.h
+++ b/src/softpars.h
@@ -11,10 +11,6 @@
 #ifndef SOFTPARS_H
 #define SOFTPARS_H
 
-
-#ifdef HAVE_CONFIG_H
- #include <config.h>
-#endif
 #include <cmath>
 #include "susy.h"
 #include "linalg.h"

--- a/src/softpoint.cpp
+++ b/src/softpoint.cpp
@@ -11,6 +11,10 @@
 
 #include "softpoint.h"
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 // Returns a string with all characters in upper case: very handy
 string ToUpper(const string & s) {
         string result;

--- a/src/softsusy.cpp
+++ b/src/softsusy.cpp
@@ -7,6 +7,21 @@
 
 #include "./softsusy.h"
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef COMPILE_TWO_LOOP_GAUGE_YUKAWA
+#include "mssm_twoloop_mt.h"
+#include "mssm_twoloop_mb.h"
+#include "mssm_twoloop_mtau.h"
+#include "mssm_twoloop_as.h"
+#endif ///< COMPILE_TWO_LOOP_GAUGE_YUKAWA
+
+#ifdef ENABLE_HIMALAYA
+#include "HierarchyCalculator.hpp"
+#endif
+
 namespace softsusy {
   extern double sw2, gnuL, guL, gdL, geL, guR, gdR, geR, yuL, yuR, ydL,
     ydR, yeL, yeR, ynuL;

--- a/src/softsusy.h
+++ b/src/softsusy.h
@@ -15,10 +15,6 @@
 #ifndef SOFTSUSY_H
 #define SOFTSUSY_H
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -36,18 +32,6 @@
 #include "higher_order.h"
 
 #define HR "----------------------------------------------------------"
-
-#ifdef COMPILE_TWO_LOOP_GAUGE_YUKAWA
-#include "mssm_twoloop_mt.h"
-#include "mssm_twoloop_mb.h"
-#include "mssm_twoloop_mtau.h"
-#include "mssm_twoloop_as.h"
-namespace softsusy { class MssmSoftsusy; }
-#endif ///< COMPILE_TWO_LOOP_GAUGE_YUKAWA
-
-#ifdef ENABLE_HIMALAYA
-#include "HierarchyCalculator.hpp"
-#endif
 
 namespace softsusy {
 

--- a/src/susy.h
+++ b/src/susy.h
@@ -20,10 +20,6 @@
 #include "rge.h"
 #include "tensor.h"
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 namespace softsusy {
   
   const static int numSusyPars = 33;

--- a/src/utils.h
+++ b/src/utils.h
@@ -12,10 +12,6 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-#ifdef HAVE_CONFIG_H
- #include <config.h>
-#endif
-
 #include "mycomplex.h"
 #include "def.h"
 #include <cstdlib>


### PR DESCRIPTION
by including config.h only in the .cpp files which check the macro
definitions.

With this change, if configure && make is called then only the .cpp
files are recompiled which include config.h (not the whole package as
before).