### PR TITLE
always match the SM(5) to the MSSM

### DIFF
--- a/src/lowe.cpp
+++ b/src/lowe.cpp
@@ -65,7 +65,9 @@ const DoubleVector QedQcd::display() const {
 //  Active flavours at energy mu
 int QedQcd::flavours(double mu) const {
   int k = 0;
-  if (mu > mf.display(mTop)) k++;
+  // do not count the top, because we always want to match the SM(5)
+  // to the SUSY model
+  // if (mu > mf.display(mTop)) k++;
   if (mu > mf.display(mCharm)) k++;
   if (mu > mf.display(mUp)) k++;
   if (mu > mf.display(mDown)) k++;
@@ -160,7 +162,9 @@ double QedQcd::qedBeta() const {
   double x;
   x = 24.0 / 9.0;
   if (displayMu() > mf.display(mCharm)) x += 8.0 / 9.0;
-  if (displayMu() > mf.display(mTop)) x += 8.0 / 9.0;
+  // do not take top into account, because we always want to match the
+  // SM(5) to the SUSY model
+  // if (displayMu() > mf.display(mTop)) x += 8.0 / 9.0;
   if (displayMu() > mf.display(mBottom)) x += 2.0 / 9.0;
   if (displayMu() > mf.display(mTau)) x += 2.0 / 3.0;
   if (displayMu() > MW) x += -7.0 / 2.0;

--- a/src/mssmUtils.cpp
+++ b/src/mssmUtils.cpp
@@ -347,8 +347,8 @@ namespace softsusy {
     /// We allow an extra factor of 10 for the precision in the predicted value
     /// of MZ compared to TOLERANCE if the program is struggling and gone beyond
     /// 10 tries - an extra 2 comes from MZ v MZ^2
-    int k = sT.size() - 2;
-    /*    if (!in.displayProblem().testSeriousProblem()) {
+    /* int k = sT.size() - 2;
+    if (!in.displayProblem().testSeriousProblem()) {
       sT(k) = 0.5 * sTfn(predictedMzSq, sqr(MZ));
       if (numTries > 10) sT(k) *= 0.1;
       } */

--- a/src/softsusy.cpp
+++ b/src/softsusy.cpp
@@ -2858,19 +2858,11 @@ double MssmSoftsusy::calcRunMbHiggs() const {
 
 
 double MssmSoftsusy::calcRunningMb() {
-  
-  /* if (displayMu() != displayMz()) {
-    ostringstream ii;
-    ii << "MssmSoftsusy::calcRunningMb called with mu=" <<
-      displayMu() << endl; 
-    throw ii.str();
-    } */
-
   /// This boundary condition needs to be set at the relevant scale  
-  double mbMZ = dataSet.displayMass(mBottom);
-  /// First convert mbMZ into DRbar value from hep-ph/9703293,0207126,9701308
+  double mbSM5 = dataSet.displayMass(mBottom);
+  /// First convert mbSM5 into DRbar value from hep-ph/9703293,0207126,9701308
   /// (SM gauge boson contributions)
-  mbMZ = mbMZ * calcRunMbDrBarConv(); 
+  mbSM5 = mbSM5 * calcRunMbDrBarConv(); 
   
   double deltaSquarkGluino = calcRunMbSquarkGluino();
   //Chargino-squark loops
@@ -2905,10 +2897,10 @@ double MssmSoftsusy::calcRunningMb() {
 				      msusy, thetat, thetab, q);
       /// AVB:  fix double-counting of eps-scalar contribution due to
       /// factorization of one-loop term 
-      double alphasMZ = sqr(displayGaugeCoupling(3)) / (4.0 * PI);
-      /// commented this + 31.0 / 72.0 * sqr(alphasMZ) / sqr(PI) ///< pure
+      double alphas = sqr(displayGaugeCoupling(3)) / (4.0 * PI);
+      /// commented this + 31.0 / 72.0 * sqr(alphas) / sqr(PI) ///< pure
       /// QCD for consistency with HO corrections
-      dzetamb-= alphasMZ / (3.0 * PI) * decoupling_corrections_dmb_one_loop; 
+      dzetamb -= alphas / (3.0 * PI) * decoupling_corrections_dmb_one_loop; 
 
   }
 #endif
@@ -2916,7 +2908,7 @@ double MssmSoftsusy::calcRunningMb() {
   /// it's NOT clear if this resummation is reliable in the full 1-loop scheme
   /// but it's at least valid to 1 loop. Warning though: if you add higher
   /// loops, you'll have to re-arrange.
-  return mbMZ / (1.0 + deltaSquarkGluino + deltaSquarkChargino + deltaHiggs
+  return mbSM5 / (1.0 + deltaSquarkGluino + deltaSquarkChargino + deltaHiggs
 		 + deltaNeutralino + dzetamb);
 }
 
@@ -6882,11 +6874,9 @@ double MssmSoftsusy::qedSusythresh(double alphaEm, double q) const {
   
   if (tree.mHpm < TOLERANCE) return 0.0;
   
-  double deltaASM = -1.0 / 3.0 ;
-  /// If this is called at a scale > mt, it's already been taken into account
-  /// in the QED x QCD running below the current scale, therefore only include
-  /// it if we are at a lower scale
-  if (displayMu() < tree.mt) deltaASM += 16.0 / 9.0 * log(tree.mt / q);
+  /// QedQcd always returns running couplings in the SM(5).
+  /// Therefore, the top threshold must be taken into account here.
+  double deltaASM = -1.0 / 3.0 + 16.0 / 9.0 * log(tree.mt / q);
   
   double deltaASusy = 
     log(tree.mHpm / q) / 3.0 + 4.0 / 9.0 * 


### PR DESCRIPTION
These changes ensure that the top threshold is correctly taken into account, i.e. we always match the SM(5) to the MSSM.