### PR TITLE
Combine uncertainties linearly which estimate different logs

### DIFF
--- a/src/softsusy.cpp
+++ b/src/softsusy.cpp
@@ -12133,8 +12133,8 @@ MssmSoftsusy::displayPhysUncertainty(TMSSMBoundaryCondition bc,
 
    // combine
    const DoubleVector total =
-      DoubleVector( v_scale.apply(sqr) +
-                    v_match.apply(sqr) +
+      v_scale.abs() +
+      DoubleVector( v_match.apply(sqr) +
                     v_mt.apply(sqr) +
                     v_alphas.apply(sqr) +
                     v_alphaem.apply(sqr) ).apply(std::sqrt);


### PR DESCRIPTION
Rationale:

 * Uncertainty estimates which are sensitive to the same kind of logs
   (e.g. varying Q_match and changing yt, alpha_s and alpha_em) could
   be combined quadratically.

 * Uncertainty estimates which are sensitive to different logs could
   be combined linearly.