### PR TITLE
fix: Remove duplicate src/supermodel/tsil/tsil.h from pkginclude_HEADERS

### DIFF
--- a/src/supermodel/supermodel.amk
+++ b/src/supermodel/supermodel.amk
@@ -36,5 +36,4 @@ src/supermodel/supermodel/sumo_params.h \
 src/supermodel/supermodel/sumo_smdata.h \
 src/supermodel/supermodel/sumo_squarks.h \
 src/supermodel/supermodel/supermodel_defs.h \
-src/supermodel/supermodel/supermodel.h \
-src/supermodel/tsil/tsil.h 
+src/supermodel/supermodel/supermodel.h


### PR DESCRIPTION
Resolves #41 

* `src/supermodel/tsil/tsil.h` is listed both in `src/supermodel/tsil.amk` (the tsil header group) and again in `src/supermodel/supermodel.amk`, so it ends up twice in `pkginclude_HEADERS`. GNU coreutils `install` will not overwrite a file it just created in the same invocation, so `make install` fails with:

```
...
install: will not overwrite just-created '.../include/softsusy/tsil.h'
```